### PR TITLE
fix: send message to specified topic in groups (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 - 📄 Add **text** and **URL bookmarks** into your Hoarder instance (tested on [v0.20.0](https://github.com/hoarder-app/hoarder/releases/tag/v0.20.0)).
 - 🤖 Obtain **AI-generated tags** in **hashtag format** for easy searching on Telegram.
-- 🔒 Support **chat ID allowlist**.
+- 🔒 Support **chat ID and thread ID allowlists**.
 - 🐳 **Production-ready Docker image** for easy **deployment**.
 
 ## Requirements
@@ -74,7 +74,7 @@ docker compose up
 Download the latest binary from [the releases page](https://github.com/Madh93/hoarderbot/releases):
 
 ```sh
-curl -L https://github.com/Madh93/hoarderbot/releases/latest/download/toffu_$(uname -s)_$(uname -m).tar.gz | tar -xz -O hoarderbot > /usr/local/bin/hoarderbot
+curl -L https://github.com/Madh93/hoarderbot/releases/latest/download/hoarderbot_$(uname -s)_$(uname -m).tar.gz | tar -xz -O hoarderbot > /usr/local/bin/hoarderbot
 chmod +x /usr/local/bin/hoarderbot
 ```
 
@@ -100,7 +100,7 @@ hoarderbot -config custom.config.tml
 
 ### Overriding with environment variables
 
-Additionally, you can overridethe configuration values using environment variables that begin with the prefix `HOARDERBOT_`. This allows you to customize your setup without needing to modify any configuration file:
+Additionally, you can override the configuration values using environment variables that begin with the prefix `HOARDERBOT_`. This allows you to customize your setup without needing to modify any configuration file:
 
 ```sh
 HOARDERBOT_LOGGING_LEVEL=debug HOARDERBOT_TELEGRAM_ALLOWLIST=chat_id_1,chat_id_2 hoarderbot

--- a/config.default.toml
+++ b/config.default.toml
@@ -12,6 +12,10 @@ token = "<YOUR_BOT_TOKEN_FROM_BOTFATHER>"
 # will interact with all chats.
 allowlist = []
 
+# Allowed thread IDs (a.k.a topics) for the bot to interact with. If empty
+# (default), the bot will interact with all threads.
+threads = []
+
 # ------------------------------------------
 # Hoarder configuration
 # ------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ var DefaultPath = filepath.Join(os.Getenv("KO_DATA_PATH"), DefaultConfigFile)
 var DefaultConfig = Config{
 	Telegram: TelegramConfig{
 		Allowlist: []int64(nil),
+		Threads:   []int(nil),
 	},
 	Hoarder: HoarderConfig{
 		URL:      "http://localhost:3000",

--- a/internal/config/telegram.go
+++ b/internal/config/telegram.go
@@ -9,6 +9,7 @@ import (
 type TelegramConfig struct {
 	Token     secret.String `koanf:"token"`     // Telegram bot token.
 	Allowlist []int64       `koanf:"allowlist"` // Allowed chat IDs for the bot to interact with.
+	Threads   []int         `koanf:"threads"`   // Allowed thread IDs (a.k.a topics) for the bot to interact with.
 }
 
 // Validate checks if the Telegram configuration is valid.

--- a/internal/hoarderbot/telegram.go
+++ b/internal/hoarderbot/telegram.go
@@ -32,8 +32,9 @@ func createTelegram(logger *logging.Logger, config *config.TelegramConfig) *Tele
 // SendNewMessage sends a new message to the user's chat.
 func (t Telegram) SendNewMessage(ctx context.Context, msg *TelegramMessage) error {
 	params := &tgbotapi.SendMessageParams{
-		ChatID: msg.Chat.ID,
-		Text:   msg.Text,
+		ChatID:          msg.Chat.ID,
+		MessageThreadID: msg.MessageThreadID,
+		Text:            msg.Text,
 	}
 
 	if _, err := t.SendMessage(ctx, params); err != nil {

--- a/internal/hoarderbot/telegram_message.go
+++ b/internal/hoarderbot/telegram_message.go
@@ -22,6 +22,10 @@ func (tm TelegramMessage) Attrs() []any {
 		"message_id", tm.ID,
 	}
 
+	if tm.IsTopicMessage {
+		attrs = append(attrs, "message_thread_id", tm.MessageThreadID)
+	}
+
 	if tm.Text != "" {
 		attrs = append(attrs, "message_text", tm.Text)
 	}


### PR DESCRIPTION
This change should be sufficient to send back to the user the bookmark to the corresponding topic in groups.

Additionally, the option `telegram.threads` is now available (as an environment variable through `HOARDERBOT_TELEGRAM_THREADS`) to specify allowed thread IDs.

Fixes  #3